### PR TITLE
feat: Add SSH deployment for private repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,24 +26,54 @@ jobs:
             # Create directory if it doesn't exist
             mkdir -p /home/ubuntu/taskmanager
             
+            # Setup SSH key for GitHub if not exists
+            if [ ! -f ~/.ssh/github_deploy_key ]; then
+              echo "Generating SSH key for GitHub access..."
+              ssh-keygen -t ed25519 -f ~/.ssh/github_deploy_key -N "" -C "ec2-deploy-$(date +%s)"
+              chmod 600 ~/.ssh/github_deploy_key
+              
+              echo "Add this public key to GitHub repo Deploy Keys:"
+              echo "=========================================="
+              cat ~/.ssh/github_deploy_key.pub
+              echo "=========================================="
+              echo "Go to: https://github.com/RECRUITMENTAI/TaskManager/settings/keys"
+              echo "Click 'Add deploy key', paste the key above, check 'Allow write access'"
+              echo "Then re-run deployment"
+              exit 1
+            fi
+            
+            # Configure SSH for GitHub
+            if [ ! -f ~/.ssh/config ] || ! grep -q "github.com" ~/.ssh/config; then
+              cat >> ~/.ssh/config << EOF
+Host github.com
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/github_deploy_key
+    StrictHostKeyChecking no
+EOF
+            fi
+            
             # Navigate to project directory
             cd /home/ubuntu/taskmanager
             
-            # Clone repo if it doesn't exist, otherwise pull
+            # Clone repo if it doesn't exist, otherwise pull (using SSH)
             if [ ! -d ".git" ]; then
-              git clone https://github.com/RECRUITMENTAI/TaskManager.git .
+              git clone git@github.com:RECRUITMENTAI/TaskManager.git .
             else
               git pull origin main
             fi
             
-            # Install/update dependencies
-            pip3 install -r requirements.txt
+            # Install/update dependencies using virtual environment
+            python3 -m venv venv
+            source venv/bin/activate
+            pip install -r requirements.txt
             
             # Kill existing Flask process if running
             pkill -f "python.*app.py" || true
             
-            # Start Flask app in background
-            nohup python3 app.py > app.log 2>&1 &
+            # Start Flask app in background using virtual environment
+            source venv/bin/activate
+            nohup python app.py > app.log 2>&1 &
             
             # Wait a moment and check if app started
             sleep 5

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,67 @@
+name: Manual Deploy to EC2
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+        - dev
+        - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to EC2 via SSH
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            echo "🚀 Starting deployment of ${{ github.event.inputs.branch }} branch..."
+            
+            # Navigate to project directory
+            cd /home/ubuntu/taskmanager
+            
+            # Pull latest changes from specified branch using PAT
+            echo "📥 Pulling latest changes from ${{ github.event.inputs.branch }}..."
+            git pull https://${{ secrets.PAT_TOKEN }}@github.com/RECRUITMENTAI/TaskManager.git ${{ github.event.inputs.branch }}
+            
+            # Activate virtual environment and install dependencies
+            echo "📦 Installing dependencies..."
+            source venv/bin/activate
+            pip install -r requirements.txt
+            
+            # Kill existing Flask process
+            echo "🔄 Restarting Flask application..."
+            pkill -f "python.*app.py" || true
+            
+            # Start Flask app in background
+            source venv/bin/activate
+            nohup python app.py > app.log 2>&1 &
+            
+            # Verify deployment
+            echo "⏳ Verifying deployment..."
+            sleep 5
+            if pgrep -f "python.*app.py" > /dev/null; then
+              echo "✅ Flask app deployed successfully!"
+              PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+              echo "🌐 App accessible at: http://$PUBLIC_IP:5000"
+              
+              # Test health endpoint
+              echo "🔍 Testing health endpoint..."
+              curl -s http://localhost:5000/health | jq '.' || curl -s http://localhost:5000/health
+              
+            else
+              echo "❌ Deployment failed! Checking logs..."
+              echo "Last 20 lines of app.log:"
+              tail -20 app.log || echo "No log file found"
+              exit 1
+            fi
+            
+            echo "🎉 Deployment completed successfully!"

--- a/app.py
+++ b/app.py
@@ -345,7 +345,12 @@ def delete(task_id):
 @app.route('/health')
 def health():
     """Health check endpoint for deployment verification."""
-    return {'status': 'healthy', 'app': 'Flask Task Manager'}
+    return {
+        'status': 'healthy', 
+        'app': 'Flask Task Manager',
+        'version': '1.1.0',
+        'features': ['CRUD tasks', 'SQLite storage', 'Responsive UI']
+    }
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
Set up SSH key authentication for EC2 to clone private repository

## Setup Process
1. **First deployment** will generate SSH key and display public key
2. **Add public key** to GitHub Deploy Keys manually  
3. **Second deployment** will use SSH key to clone repo successfully

## Changes
- Generate ED25519 SSH key on EC2 if not present
- Display public key in deployment logs for easy copying
- Configure SSH config for GitHub access
- Switch from HTTPS to SSH clone (git@github.com:...)
- Use Python virtual environment to avoid externally-managed error

## Instructions
1. Merge this PR 
2. First deployment will show public key in logs
3. Copy key to: https://github.com/RECRUITMENTAI/TaskManager/settings/keys
4. Click 'Add deploy key', paste key, check 'Allow write access'
5. Re-run deployment - should succeed

🤖 Generated with [Claude Code](https://claude.ai/code)